### PR TITLE
fix: pull not possible due to wrong content type

### DIFF
--- a/lib/Controller/KoreaderController.php
+++ b/lib/Controller/KoreaderController.php
@@ -581,7 +581,7 @@ class KoreaderController extends Controller {
      */
     private function createKoreaderResponse(array $data, int $statusCode = 200): JSONResponse {
         $response = new JSONResponse($data, $statusCode);
-        $response->addHeader('Content-Type', 'application/vnd.koreader.v1+json; charset=utf-8');
+        $response->addHeader('Content-Type', 'application/json');
         return $response;
     }
 


### PR DESCRIPTION
This fixes: https://github.com/international-omelette/nextcloud-koreader-companion/issues/4

and it's related to: https://github.com/koreader/koreader/issues/13539

tl:dr
There is a "bug" in the Spore Lua library. See: https://github.com/koreader/koreader/issues/13539#issuecomment-2816917402